### PR TITLE
Changed tooltip display to none when not hovering

### DIFF
--- a/src/components/Tooltips/Tooltip.jsx
+++ b/src/components/Tooltips/Tooltip.jsx
@@ -59,7 +59,7 @@ const TooltipToggle = styled.a`
 
 const TooltipContent = styled.div`
   display: ${({ active }) => (active ? 'block' : 'none')};
-  z-index: 0;
+  z-index: 9;
   position: absolute;
   left: 50%;
   bottom: 100%;

--- a/src/components/Tooltips/Tooltip.jsx
+++ b/src/components/Tooltips/Tooltip.jsx
@@ -58,7 +58,8 @@ const TooltipToggle = styled.a`
 `;
 
 const TooltipContent = styled.div`
-  z-index: 9;
+  display: ${({ active }) => (active ? 'block' : 'none')};
+  z-index: 0;
   position: absolute;
   left: 50%;
   bottom: 100%;

--- a/src/components/Tooltips/Tooltip.jsx
+++ b/src/components/Tooltips/Tooltip.jsx
@@ -58,7 +58,7 @@ const TooltipToggle = styled.a`
 `;
 
 const TooltipContent = styled.div`
-  display: ${({ active }) => (active ? 'block' : 'none')};
+  visibility: ${({ active }) => (active ? 'visible' : 'hidden')};
   z-index: 9;
   position: absolute;
   left: 50%;
@@ -73,6 +73,7 @@ const TooltipContent = styled.div`
     active ? 'translate(-50%, 0)' : 'translate(-50%, 1em)'};
 
   font-family: ${({ theme }) => theme.font};
+  transition: all 0.2s ease;
   font-size: 14px;
   line-height: 1.8rem;
   color: white;


### PR DESCRIPTION
Buttons that were under the tooltip content could not be clicked, even when the tooltip was not displayed.