### PR TITLE
:wrench: fix tab functionality on dropdown and themepicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wg-fe-ui",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "main": "index.js",
   "scripts": {
     "build": "babel src -d dist --copy-files",

--- a/src/components/Inputs/DropDown.jsx
+++ b/src/components/Inputs/DropDown.jsx
@@ -168,7 +168,7 @@ const Input = styled.div`
   transition: all .2s;
   &:focus {
     outline: 0;
-    border: 1px solid ${({ theme }) => theme.brand.primary};
+    border: 1px solid ${({ theme, disabled }) => !disabled ? theme.brand.primary : 'rgba(0,0,0,0)'};
   }
 `;
 

--- a/src/components/Inputs/DropDown.jsx
+++ b/src/components/Inputs/DropDown.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import styled from 'styled-components';
 import { element, array, bool, string, object, func } from 'prop-types';
 
@@ -20,10 +20,13 @@ const DropDown = ({
   className,
   otherProps,
   placeholder,
+  opensUp,
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const [currentValue, setCurrentValue] = useState(value);
   const [currentOption, setCurrentOption] = useState();
+  const containerRef = useRef();
+  const inputRef = useRef();
 
   useEffect(() => {
     const result = options.filter(obj => {
@@ -33,9 +36,42 @@ const DropDown = ({
     setCurrentOption(result[0]);
   }, [currentValue]);
 
+
+  const handleInputClickOutside = (e) => {
+    if (disabled || showMenu) return;
+    if (containerRef.current && !containerRef.current.contains(e.target)) {
+      setShowMenu(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener('click', handleInputClickOutside, true);
+    return () => {
+      document.removeEventListener('click', handleInputClickOutside, true);
+    };
+  }, []);
+
   const handleInputClick = () => {
     if (!disabled) {
       setShowMenu(!showMenu);
+    }
+  };
+
+  const handleInputKey = (e) => {
+    if (!disabled) {
+      if (e.keyCode === 32) {
+        e.preventDefault();
+        setShowMenu(!showMenu);
+      }
+    }
+  };
+
+  const handleInputKeyOption = (e, value) => {
+    if (!disabled) {
+      if (e.keyCode === 32) {
+        e.preventDefault();
+        handleOptionClick(value);
+      }
     }
   };
 
@@ -46,17 +82,21 @@ const DropDown = ({
 
     onValueChange(result);
     setCurrentValue(result[0].value);
-
+    inputRef.current.focus();
     setShowMenu(false);
   };
 
   return (
-    <DropDownWrapper disabled={disabled} className={className} {...otherProps}>
+    <DropDownWrapper ref={containerRef} disabled={disabled} className={className} {...otherProps}>
       <Label for={name}>{children}</Label>
 
       <StyledDropDown>
         <Input
-          onClick={() => handleInputClick()}
+          ref={inputRef}
+          onKeyDown={handleInputKey}
+          tabIndex="0"
+          opensUp={opensUp}
+          onClick={handleInputClick}
           show={showMenu}
           disabled={disabled}
         >
@@ -66,11 +106,13 @@ const DropDown = ({
           </DropDownIcon>
         </Input>
 
-        <Menu show={showMenu}>
+        <Menu show={showMenu} opensUp={opensUp}>
           {options.map(option => {
             return (
               <MenuOption
                 key={option.value}
+                onKeyDown={e => handleInputKeyOption(e, option.value)}
+                tabIndex="0"
                 onClick={() => handleOptionClick(option.value)}
               >
                 <H4>{option.title}</H4>
@@ -111,7 +153,8 @@ const Input = styled.div`
   height: 4.5rem;
   border: 1px solid #e4e4e4;
   background-color: ${({ disabled }) => (disabled ? '#E4E4E4' : 'white')};
-  border-radius: ${({ show }) => (show ? '5px 5px 0 0' : '5px')};
+  border-radius: ${({ show, opensUp }) =>
+    show && opensUp ? '0 0 5px 5px' : show  ? '5px 5px 0 0' : '5px'};
   padding: 1.2rem 1.8rem;
   display: flex;
   align-items: center;
@@ -122,6 +165,11 @@ const Input = styled.div`
   line-height: 2rem;
   letter-spacing: 0.02em;
   color: #222;
+  transition: all .2s;
+  &:focus {
+    outline: 0;
+    border: 1px solid ${({ theme }) => theme.brand.primary};
+  }
 `;
 
 const DropDownIcon = styled.div`
@@ -136,18 +184,20 @@ const DropDownIcon = styled.div`
 
 const Menu = styled.div`
   z-index: 9999;
-  display: ${({ show }) => (show ? 'block' : 'none')};
+  visibility: ${({ show }) => (show ? 'visible' : 'hidden')};
   position: absolute;
   left: 0;
-  top: 45px;
+  top: ${({ opensUp }) => opensUp ? 'auto' : '100%'};
+  bottom: ${({ opensUp }) => opensUp ? '100%' : 'auto'};
   width: 100%;
-  max-height: 30rem;
+  max-height: ${({ show }) => (show ? '30rem' : '0')};
   overflow-y: scroll;
 
   background-color: white;
   border: 1px solid #e4e4e4;
   border-top: 0;
-  border-radius: 0 0 5px 5px;
+  border-radius: ${({ opensUp }) => opensUp ? '5px 5px 0 0' : '0 0 5px 5px'};
+  transition: max-height .2s ease, visibility .2s ease;
 `;
 
 const MenuOption = styled.div`
@@ -162,6 +212,11 @@ const MenuOption = styled.div`
 
   &:hover {
     background-color: #f0f1f3;
+  }
+
+  &:focus {
+    outline: none;
+    border: 1px solid ${({ theme }) => theme.brand.primary};
   }
 `;
 
@@ -180,6 +235,8 @@ DropDown.propTypes = {
   disabled: bool,
   /** Extra classnames to be passed to the element. */
   className: string,
+  /** Opens the dropdown up instead of down */
+  opensUp: string,
   /** Extra props to be passed to the element. */
   otherProps: object,
   placeholder: string,

--- a/src/components/Inputs/ThemePicker.jsx
+++ b/src/components/Inputs/ThemePicker.jsx
@@ -144,7 +144,7 @@ const ThemePickerInput = styled.div`
 
   &:focus {
     outline: 0;
-    border: 1px solid ${({ theme }) => theme.brand.primary};
+    border: 1px solid ${({ theme, disabled }) => !disabled ? theme.brand.primary : 'rgba(0,0,0,0)'};
   }
 `;
 

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -537,6 +537,7 @@ storiesOf('Low level blocks/Inputs', module)
         <DropDown
           name="test-dropdown"
           options={DropDownOptions}
+          opensUp={boolean('Open up?', false)}
           onValueChange={picked => {
             console.log(picked);
           }}


### PR DESCRIPTION
functionalities:

- Clicking outside the menu closes the dropdown
- Tabbing now goes to the input
- pressing space while focusing the input opens / closes the dropdown
- use tab to navigate through dropdown options and use space to select
- Add upwards dropdown menu option for DropDown