### PR TITLE
onClose error 'function is undefined'

### DIFF
--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -204,6 +204,7 @@ Modal.propTypes = {
 };
 
 Modal.defaultProps = {
+  onClose: () => {},
   canClose: true,
   showModal: false,
   toastHideTime: 5,

--- a/src/components/Modals/ModalWithSteps.jsx
+++ b/src/components/Modals/ModalWithSteps.jsx
@@ -399,6 +399,7 @@ ModalWithSteps.propTypes = {
 };
 
 ModalWithSteps.defaultProps = {
+  onClose: () => {},
   canClose: true,
   showModal: false,
   toastHideTime: 5,


### PR DESCRIPTION
onClose function in the Modal component in design system didn't have a default value, so it showed up as undefined if not provided.
Provided a default value for this.