### PR TITLE
Fix paste issues for date input

### DIFF
--- a/src/components/Inputs/DateInputV4.jsx
+++ b/src/components/Inputs/DateInputV4.jsx
@@ -332,6 +332,15 @@ const DateInputV4 = ({
     handleBlur(changedDate, returnType);
   };
 
+  const handleOnPaste = (e, maxLength) => {
+    const pastedText = (e.clipboardData || window.clipboardData).getData(
+      'text',
+    );
+    // Avoids the ability to paste text with alphabetic characeters and/or longer than the given max length
+    if (!new RegExp(`^\\d{1,${maxLength}}$`).test(pastedText))
+      e.preventDefault();
+  };
+
   return (
     <Container
       className={className}
@@ -361,6 +370,7 @@ const DateInputV4 = ({
             onKeyDown={onKeyDown}
             type="number"
             data-test-id={`${dataTestId}_day`}
+            onPaste={e => handleOnPaste(e, 2)}
           />
           <Slash>/</Slash>
           <DateInput
@@ -375,6 +385,7 @@ const DateInputV4 = ({
             onKeyDown={onKeyDown}
             type="number"
             data-test-id={`${dataTestId}_month`}
+            onPaste={e => handleOnPaste(e, 2)}
           />
           <Slash>/</Slash>
           <DateInput
@@ -390,6 +401,7 @@ const DateInputV4 = ({
             type="number"
             year
             data-test-id={`${dataTestId}_year`}
+            onPaste={e => handleOnPaste(e, 4)}
           />
           {withIcon && error && touched ? (
             <StyledErrormark color="#F74040" />


### PR DESCRIPTION
When trying to paste something like `E254` it would paste this in the date field making it impossible to remove anything in the date field. Users can get stuck here.

Go to the vercel link and go to `DateInputV4`. Test pasting the following strings in the day and/or month field:
- `17` should work
- `117` should not work
- `E` should not work
- `E254` should not work
- `1` should work

For the year field:
- `17` should work
- `117` should work
- `E254` should not work
- `E4` should not work
- `1` should work
- `2017` should work