### PR TITLE
Fixed semantics for tab items

### DIFF
--- a/src/components/Navigation/Tabs.jsx
+++ b/src/components/Navigation/Tabs.jsx
@@ -121,7 +121,11 @@ const Tab = ({
       width={width}
       {...rest}
     >
-      {children}
+      {typeof children === 'string' || typeof children === 'number' ? (
+        <p>{children}</p>
+      ) : (
+        { children }
+      )}
     </Item>
   );
 };


### PR DESCRIPTION
Reasoning:
1. The semantics were incorrect. Text belongs inside a `p` or `span` tag, not inside an `li` tag.
2. Using things like text-overflow and such is now possible thanks to the `p` tag.