### PR TITLE
Fixed breaking bug with the new Tabs children semantics implementation

### DIFF
--- a/src/components/Navigation/Tabs.jsx
+++ b/src/components/Navigation/Tabs.jsx
@@ -124,7 +124,7 @@ const Tab = ({
       {typeof children === 'string' || typeof children === 'number' ? (
         <p>{children}</p>
       ) : (
-        { children }
+        children
       )}
     </Item>
   );


### PR DESCRIPTION
`children` was put in an object (stupid mistake)